### PR TITLE
Fix outdated package name

### DIFF
--- a/lightseq/lightseq_async_attn.py
+++ b/lightseq/lightseq_async_attn.py
@@ -21,7 +21,7 @@ try:
 except:
     pass
 
-from lasync_communication import (is_last_time, is_compute_for_local_query, is_sync_from_remote, is_idle, print_and_reset_comm_stats, 
+from async_communication import (is_last_time, is_compute_for_local_query, is_sync_from_remote, is_idle, print_and_reset_comm_stats, 
         launch_async_handles, wait_async_handles, maybe_send_recv_fwd_qkvo, maybe_send_recv_bwd_qkvo, maybe_send_recv_bwd_last_dkv, reset_global_memory_buffer,
         maybe_get_set_global_memory_buffer, maybe_get_set_global_memory_buffer_bwd, initialize_distributed, get_sequence_parallel_size, get_sequence_parallel_rank)
 

--- a/lightseq/train_lightseq_no_trainer.py
+++ b/lightseq/train_lightseq_no_trainer.py
@@ -6,8 +6,8 @@ from tqdm import tqdm
 import functools
 
 # import fastckpt before transformers
-from lightseq_ckpt_monkey_patch import replace_hf_ckpt_with_fast_ckpt, clear_all_buffers_at_the_end_of_training
-replace_hf_ckpt_with_fast_ckpt()
+from lightseq_ckpt_monkey_patch import replace_hf_ckpt_with_new_ckpt, clear_all_buffers_at_the_end_of_training
+replace_hf_ckpt_with_new_ckpt()
 
 import numpy as np
 import torch


### PR DESCRIPTION
`lasync_communication` and `lightseq_ckpt_monkey_patch.replace_hf_ckpt_with_fast_ckpt` not found.

rename to

```
from async_communication import
```
and
```
from lightseq_ckpt_monkey_patch import replace_hf_ckpt_with_new_ckpt, clear_all_buffers_at_the_end_of_training
replace_hf_ckpt_with_new_ckpt()
```